### PR TITLE
refactor: add parameter progress to bfcadd

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: BiocFileCache
 Title: Manage Files Across Sessions
-Version: 2.15.1
+Version: 2.15.2
 Authors@R: c(person("Lori", "Shepherd",
       email = "lori.shepherd@roswellpark.org",
       role = c("aut", "cre")),

--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,10 @@
 CHANGES IN VERSION 2.15
 ----------------------
 
+USER VISIBLE CHANGE
+
+    o (2.15.2) Add parameter `progress` to `bcfadd()`.
+
 BUG FIX
 
     o (2.15.1) Fix issue trying to create multiple caches in single R session

--- a/R/BiocFileCache-class.R
+++ b/R/BiocFileCache-class.R
@@ -306,7 +306,7 @@ setGeneric("bfcadd",
         x, rname, fpath = rname, rtype=c("auto", "relative", "local", "web"),
         action=c("copy", "move", "asis"), proxy="",
         download=TRUE, config=list(), ext=NA_character_,
-        fname=c("unique", "exact"),...
+        fname=c("unique", "exact"), progress=httr::progress(con=stderr()), ...
     ) standardGeneric("bfcadd"),
     signature = "x"
 )
@@ -319,12 +319,12 @@ setMethod("bfcadd", "missing",
         x, rname, fpath = rname, rtype=c("auto", "relative", "local", "web"),
         action=c("copy", "move", "asis"), proxy="",
         download=TRUE, config=list(), ext=NA_character_,
-        fname=c("unique", "exact"), ...
+        fname=c("unique", "exact"), progress=httr::progress(con=stderr()), ...
     )
 {
     bfcadd(x=BiocFileCache(), rname=rname, fpath=fpath, rtype=rtype,
            action=action, proxy=proxy, download=download, config=config,
-           ext=ext, fname=fname,...)
+           ext=ext, fname=fname, progress=progress, ...)
 })
 
 #' @describeIn BiocFileCache Add an existing resource to the database
@@ -345,6 +345,11 @@ setMethod("bfcadd", "missing",
 #' @param proxy character(1) (Optional) proxy server.
 #' @param download logical(1) If \code{rtype=web}, should remote
 #'     resource be downloaded locally immediately.
+#' @param progress definition of the progress bar to use. This parameter is
+#'     passed to the \code{httr::GET()} function and defaults to
+#'     \code{httr::progress(con = stderr())}. Set to `progress = list()` to
+#'     disable the progress bar.
+#'     See help on \code{httr::progress()} for more information.
 #' @param config list() passed as config argument in \code{httr::GET}
 #' @param ... For 'bfcadd', 'bfcupdate' and 'bfcdownload': Additional
 #'     arguments passed to internal download functions for use with
@@ -384,7 +389,8 @@ setMethod("bfcadd", "BiocFileCache",
         rtype = c("auto", "relative", "local", "web"),
         action = c("copy", "move", "asis"),
         proxy = "", download = TRUE, config = list(), ext=NA_character_,
-        fname=c("unique", "exact"),...)
+        fname=c("unique", "exact"),
+        progress = httr::progress(con = stderr()), ...)
 {
     stopifnot(
         is.character(rname), length(rname) > 0L, !any(is.na(rname)),
@@ -418,7 +424,8 @@ setMethod("bfcadd", "BiocFileCache",
                 }
                 )
         } else if (download) {              # rtype == "web"
-            .util_download(x, rid[i], proxy, config, "bfcadd()", ...)
+            .util_download(x, rid[i], proxy, config, "bfcadd()",
+                           progress, ...)
         }
     }
 
@@ -621,7 +628,8 @@ setMethod("bfcupdate", "missing",
 #' @exportMethod bfcupdate
 setMethod("bfcupdate", "BiocFileCache",
     function(x, rids, ..., rname=NULL, rpath=NULL, fpath=NULL,
-             proxy="", config=list(), ask=TRUE)
+             proxy="", config=list(), ask=TRUE,
+             progress = httr::progress(con = stderr()))
 {
     stopifnot(!missing(rids), all(rids %in% bfcrid(x)))
     stopifnot(
@@ -686,7 +694,8 @@ setMethod("bfcupdate", "BiocFileCache",
             }
             if (doit) {
                 .util_download_and_rename(
-                    x, rids[i], proxy, config, "bfcupdate()", fpath[i], ...
+                    x, rids[i], proxy, config, "bfcupdate()", fpath[i],
+                    progress = progress, ...
                 )
                 .sql_set_fpath(x, rids[i], fpath[i])
             }
@@ -1083,7 +1092,8 @@ setMethod("bfcdownload", "missing",
 #' @aliases bfcdownload
 #' @exportMethod bfcdownload
 setMethod("bfcdownload", "BiocFileCache",
-    function(x, rid, proxy="", config=list(), ask=TRUE, FUN, ...)
+          function(x, rid, proxy="", config=list(), ask=TRUE, FUN,
+                   progress = httr::progress(con = stderr()), ...)
 {
     stopifnot(
         !missing(rid), length(rid) > 0L,
@@ -1102,7 +1112,7 @@ setMethod("bfcdownload", "BiocFileCache",
     }
     if (doit)
         .util_download_and_rename(x, rid, proxy, config, "bfcdownload()",
-                                  FUN=FUN, ...)
+                                  FUN=FUN, progress = progress, ...)
 
     bfcrpath(x, rids=rid)
 })

--- a/R/httr.R
+++ b/R/httr.R
@@ -42,7 +42,8 @@
 
 #' @importFrom utils packageVersion
 .httr_download <-
-    function(websource, localfile, proxy, config, ...)
+    function(websource, localfile, proxy, config,
+             progress = httr::progress(con = stderr()), ...)
 {
     ## retrieve file from hub to cache
     tryCatch({
@@ -61,10 +62,10 @@
         ## Download the resource in a way that supports https
         if (interactive() && (packageVersion("httr") > "1.0.0")) {
             response <- suppressWarnings({
-                GET(websource, progress(con = stderr()), config=config,
+                GET(websource, progress, config=config,
                     write_disk(localfile, overwrite=TRUE), proxy, ...)
             })
-            cat("\n") ## line break after progress bar
+            if (length(progress)) cat("\n") ## line break after progress bar
         } else {
             response <- suppressWarnings({
                 GET(websource, write_disk(localfile, overwrite=TRUE),

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -120,13 +120,15 @@
 }
 
 .util_download <-
-    function(bfc, rid, proxy, config, call, ...)
+    function(bfc, rid, proxy, config, call,
+             progress = httr::progress(con = stderr()), ...)
 {
     rpath <- .sql_get_rpath(bfc, rid)
     fpath <- .sql_get_fpath(bfc, rid)
     status <- Map(
         .httr_download, fpath, rpath,
-        MoreArgs = list(proxy = proxy, config = config, ...)
+        MoreArgs = list(proxy = proxy, config = config,
+                        progress = progress, ...)
     )
     ok <- vapply(status, isTRUE, logical(1))
     if (!all(ok)) {
@@ -147,10 +149,11 @@
 
 .util_download_and_rename <-
     function(bfc, rid, proxy, config, call, fpath = .sql_get_fpath(bfc, rid),
-             FUN, ...)
+             FUN, progress = httr::progress(con = stderr()), ...)
 {
     rpath <- .sql_get_rpath(bfc, rid)
     force(fpath)
+    force(progress)
 
     # The connection is not actually necessary - but we just use it to
     # handle thread-safe locking, specifically to avoid race conditions
@@ -160,11 +163,13 @@
 
     if (missing(FUN))
         FUN <- file.rename
-
+    
     status <- Map(function(rpath, fpath) {
+        
         temppath <- tempfile(tmpdir=bfccache(bfc))
 
-        status <- .httr_download(fpath, temppath, proxy, config, ...)
+        status <- .httr_download(fpath, temppath, proxy, config,
+                                 progress, ...)
         if (!status)
             return("download failed")
 

--- a/man/BiocFileCache-class.Rd
+++ b/man/BiocFileCache-class.Rd
@@ -138,6 +138,7 @@ bfcrid(x)
   config = list(),
   ext = NA_character_,
   fname = c("unique", "exact"),
+  progress = httr::progress(con = stderr()),
   ...
 )
 
@@ -152,6 +153,7 @@ bfcrid(x)
   config = list(),
   ext = NA_character_,
   fname = c("unique", "exact"),
+  progress = httr::progress(con = stderr()),
   ...
 )
 
@@ -180,7 +182,8 @@ bfcrid(x)
   fpath = NULL,
   proxy = "",
   config = list(),
-  ask = TRUE
+  ask = TRUE,
+  progress = httr::progress(con = stderr())
 )
 
 bfcmeta(x, name, ...) <- value
@@ -219,7 +222,16 @@ bfcmeta(x, name, ...) <- value
 
 \S4method{bfcdownload}{missing}(x, rid, proxy = "", config = list(), ask = TRUE, FUN, ...)
 
-\S4method{bfcdownload}{BiocFileCache}(x, rid, proxy = "", config = list(), ask = TRUE, FUN, ...)
+\S4method{bfcdownload}{BiocFileCache}(
+  x,
+  rid,
+  proxy = "",
+  config = list(),
+  ask = TRUE,
+  FUN,
+  progress = httr::progress(con = stderr()),
+  ...
+)
 
 \S4method{bfcremove}{missing}(x, rids)
 
@@ -326,6 +338,12 @@ in current location but save the path in the cache. If 'rtype
 resource be downloaded locally immediately.}
 
 \item{config}{list() passed as config argument in \code{httr::GET}}
+
+\item{progress}{definition of the progress bar to use. This parameter is
+passed to the \code{httr::GET()} function and defaults to
+\code{httr::progress(con = stderr())}. Set to `progress = list()` to
+disable the progress bar.
+See help on \code{httr::progress()} for more information.}
 
 \item{rids}{character() Vector of rids.}
 


### PR DESCRIPTION
- Add parameter `progress` to `bfcadd()` to allow configuration of the *httr* progress bar.