### PR TITLE
Fix bug with using proxy as an argument to functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: BiocFileCache
 Title: Manage Files Across Sessions
-Version: 2.99.3
+Version: 2.99.4
 Authors@R: c(person("Lori", "Shepherd",
       email = "lori.shepherd@roswellpark.org",
       role = c("aut", "cre")),

--- a/NEWS
+++ b/NEWS
@@ -11,7 +11,7 @@ BUG FIX
     add to cache without caching information. Additionally fix bug so config can
     be passed down to HEAD call from bfcneedsupdate, bfcadd, and bfcrpath.
 
-    o (2.99.3) Fix bug to pass proxy down to HEAD call
+    o (2.99.4) Fix bug to pass proxy down to HEAD call
 
 NEW FEATURE
 

--- a/NEWS
+++ b/NEWS
@@ -11,6 +11,8 @@ BUG FIX
     add to cache without caching information. Additionally fix bug so config can
     be passed down to HEAD call from bfcneedsupdate, bfcadd, and bfcrpath.
 
+    o (2.99.3) Fix bug to pass proxy down to HEAD call
+
 NEW FEATURE
 
     o (2.99.2) Add progress argument to bfcadd/bfcdownload to control if a

--- a/R/BiocFileCache-class.R
+++ b/R/BiocFileCache-class.R
@@ -974,7 +974,7 @@ setMethod("bfccount", "tbl_bfc",
 
 #' @export
 setGeneric("bfcneedsupdate",
-    function(x, rids, ...) standardGeneric("bfcneedsupdate"),
+    function(x, rids, ..., proxy="", config=list()) standardGeneric("bfcneedsupdate"),
     signature = "x"
 )
 
@@ -982,9 +982,9 @@ setGeneric("bfcneedsupdate",
 #' @aliases bfcneedsupdate,missing-method
 #' @exportMethod bfcneedsupdate
 setMethod("bfcneedsupdate", "missing",
-    function(x, rids, ...)
+    function(x, rids, ..., proxy="", config=list())
 {
-    bfcneedsupdate(x=BiocFileCache(), rids=rids)
+    bfcneedsupdate(x=BiocFileCache(), rids=rids, proxy=proxy, config=config)
 })
 
 #' @describeIn BiocFileCache check if a resource needs to be updated
@@ -1003,7 +1003,7 @@ setMethod("bfcneedsupdate", "missing",
 #' @aliases bfcneedsupdate
 #' @exportMethod bfcneedsupdate
 setMethod("bfcneedsupdate", "BiocFileCacheBase",
-    function(x, rids, ..., config=list())
+    function(x, rids, ..., proxy="", config=list())
 {
     if (missing(rids))
         rids <- .get_all_web_rids(x)
@@ -1016,7 +1016,7 @@ setMethod("bfcneedsupdate", "BiocFileCacheBase",
         fpath <- .sql_get_fpath(x, rid)
         file_etag <-  .sql_get_etag(x, rid)
         file_expires <- .sql_get_expires(x, rid)
-        cache_info <- .httr_get_cache_info(fpath, config)
+        cache_info <- .httr_get_cache_info(fpath, proxy, config)
         web_time <- cache_info[["modified"]]
         web_etag <- cache_info[["etag"]]
 

--- a/R/httr.R
+++ b/R/httr.R
@@ -46,7 +46,7 @@
 }
 
 .httr_get_cache_info <-
-    function(link, config)
+    function(link, proxy, config)
 {
     if(missing(config))
        config <- NULL
@@ -56,9 +56,21 @@
     } else {
         stopifnot(is.list(config))
     }
-
+    
+    if (missing(proxy)){
+        proxy <- ""
+    }         
+    if (proxy == ""){
+        proxy <- NULL
+    }         
+    
     req <- request(link) %>%
         req_method("HEAD")
+    
+    # Apply the proxy if it's not NULL
+    if (!is.null(proxy)) {
+        req <- req %>% req_proxy(proxy)
+    }
 
     # Apply the config if it's not NULL
     if (!is.null(config)) {

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -107,12 +107,12 @@
 }
 
 .util_set_cache_info <-
-    function(bfc, rid, fpath = .sql_get_fpath(bfc, rid), config)
+    function(bfc, rid, fpath = .sql_get_fpath(bfc, rid), proxy, config)
 {
     if (length(rid) == 0L)
         return(bfc)
 
-    cache_info <- .httr_get_cache_info(fpath, config)
+    cache_info <- .httr_get_cache_info(fpath, proxy, config)
     .sql_set_last_modified(bfc, rid, cache_info[["modified"]])
     .sql_set_etag(bfc, rid, cache_info[["etag"]])
     .sql_set_expires(bfc, rid, cache_info[["expires"]])
@@ -139,7 +139,7 @@
             call. = FALSE
         )
     }
-    .util_set_cache_info(bfc, rid[ok], config=config)
+    .util_set_cache_info(bfc, rid[ok], proxy=proxy, config=config)
 
     if (!all(ok))
         stop(call, " failed; see warnings()")
@@ -192,7 +192,7 @@
             call. = FALSE
         )
 
-    .util_set_cache_info(bfc, rid[ok], fpath[ok], config=config)
+    .util_set_cache_info(bfc, rid[ok], fpath[ok], proxy=proxy, config=config)
 
     if (!all(ok))
         stop("download failed; see warnings()", call.=FALSE)

--- a/man/BiocFileCache-class.Rd
+++ b/man/BiocFileCache-class.Rd
@@ -216,9 +216,9 @@ bfcmeta(x, name, ...) <- value
 
 \S4method{bfccount}{tbl_bfc}(x)
 
-\S4method{bfcneedsupdate}{missing}(x, rids, ...)
+\S4method{bfcneedsupdate}{missing}(x, rids, ..., proxy = "", config = list())
 
-\S4method{bfcneedsupdate}{BiocFileCacheBase}(x, rids, ..., config = list())
+\S4method{bfcneedsupdate}{BiocFileCacheBase}(x, rids, ..., proxy = "", config = list())
 
 \S4method{bfcdownload}{missing}(
   x,


### PR DESCRIPTION
I don't have a good way to test but this should fix the error reported in https://github.com/Bioconductor/BiocFileCache/issues/54  when trying to use the argument and not the environment variable. 